### PR TITLE
Try both importlib locations - Needed in DJango > 1.8

### DIFF
--- a/django_callable_perms/utils.py
+++ b/django_callable_perms/utils.py
@@ -1,6 +1,11 @@
 def autoload_permission_checks():
     from django.conf import settings
-    from django.utils.importlib import import_module
+    # Workaround for Django 1.8 
+    try:
+        from django.utils.importlib import import_module
+    except ImportError:
+        from importlib import import_module
+
     from django.utils.module_loading import module_has_submodule
     
     for app in settings.INSTALLED_APPS:


### PR DESCRIPTION
Hey David,

ich hab django_callable_perms nach wie vor am laufen :-)

Seit 1.8 stimmt nur ein Import nicht. Wäre super, wenn du den Pull Request annehmen würdest.

Habe es auch Rückwärtskompatibel geschrieben.

Viele Grüße
Martin